### PR TITLE
Add architectures stanza

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,6 +10,10 @@ description: |
 grade: stable
 confinement: classic
 
+architectures:
+  - build-on: amd64
+  - build-on: armhf
+
 apps:
   teleconsole:
     command: teleconsole
@@ -20,5 +24,4 @@ parts:
     source: 
       - on armhf: https://github.com/gravitational/teleconsole/releases/download/0.4.0/teleconsole-v0.4.0-linux-arm.tar.gz 
       - on amd64: https://github.com/gravitational/teleconsole/releases/download/0.4.0/teleconsole-v0.4.0-linux-amd64.tar.gz
-      - on i386: fail
-      - on arm64: fail
+


### PR DESCRIPTION
Adding the architectures stanza which means we don't waste time building on unsupported architectures. See [this thread](https://forum.snapcraft.io/t/architectures/4972) for more details.